### PR TITLE
scripts: return error if tests fail

### DIFF
--- a/script/test
+++ b/script/test
@@ -144,11 +144,10 @@ REGULAR_PUNICA_PID=$(run_punica "regular" "-d ${PROJECT_ROOT_DIR}/tests/rest/_da
 SECURE_PUNICA_PID=$(run_punica "secure" "-c ${PROJECT_ROOT_DIR}/tests/rest/secure.cfg")
 
 echo "==> Running coverage tests..."
+test_status=1
 if eval "cd ${PROJECT_ROOT_DIR}/tests/rest" && npm install && npm test
 then
-    coverage_tests_status=0
-else
-    coverage_tests_status=1
+    test_status=0
 fi
 cd -
 
@@ -158,3 +157,5 @@ stop_punica $SECURE_PUNICA_PID
 eval "rm -f ${PROJECT_ROOT_DIR}/tests/rest/_database.json"
 
 echo "Finished testing!"
+
+exit $test_status

--- a/tests/rest/devices.spec.js
+++ b/tests/rest/devices.spec.js
@@ -1,4 +1,4 @@
-const chai = require('chaiZ');
+const chai = require('chai');
 const chai_http = require('chai-http');
 const should = chai.should();
 var server = require('./server-if');

--- a/tests/rest/devices.spec.js
+++ b/tests/rest/devices.spec.js
@@ -1,4 +1,4 @@
-const chai = require('chai');
+const chai = require('chaiZ');
 const chai_http = require('chai-http');
 const should = chai.should();
 var server = require('./server-if');


### PR DESCRIPTION
If npm test fails, the test script does not return error and Travis shows true-negative status.